### PR TITLE
PHP7.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: php
 php:
-    - "5.6"
     - "7.0"
+    - "7.1"
+    - "7.2"
+    - "nightly"
 before_script:
     - "composer install"
     - "composer require satooshi/php-coveralls"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
 		"php": ">=5.6.3",
 		"ext-gmp": "*",
 		"sop/asn1": "^2.0.0",
-		"sop/crypto-encoding": "^0.1.0"
+		"sop/crypto-encoding": "^0.1.0",
+		"phpunit/phpunit": "^6.4"
 	},
 	"autoload": {
 		"psr-4": {

--- a/lib/CryptoTypes/AlgorithmIdentifier/AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier;
 
 use ASN1\Type\Constructed\Sequence;
@@ -104,7 +106,7 @@ abstract class AlgorithmIdentifier implements AlgorithmIdentifierType
      * {@inheritdoc}
      *
      */
-    public function toASN1()
+    public function toASN1(): Sequence
     {
         $elements = array(new ObjectIdentifier($this->_oid));
         $params = $this->_paramsASN1();

--- a/lib/CryptoTypes/AlgorithmIdentifier/AlgorithmIdentifierFactory.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/AlgorithmIdentifierFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier;
 
 use ASN1\Type\Constructed\Sequence;
@@ -81,7 +83,7 @@ class AlgorithmIdentifierFactory
      * @param string $oid Object identifier in dotted format
      * @return string|null Fully qualified class name or null if not supported
      */
-    public function getClass($oid)
+    public function getClass(string $oid)
     {
         // if OID is provided by this factory
         if (array_key_exists($oid, self::MAP_OID_TO_CLASS)) {
@@ -102,7 +104,7 @@ class AlgorithmIdentifierFactory
      * @param Sequence $seq
      * @return AlgorithmIdentifier
      */
-    public function parse(Sequence $seq)
+    public function parse(Sequence $seq): AlgorithmIdentifier
     {
         $oid = $seq->at(0)
             ->asObjectIdentifier()

--- a/lib/CryptoTypes/AlgorithmIdentifier/AlgorithmIdentifierProvider.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/AlgorithmIdentifierProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier;
 
 /**
@@ -17,7 +19,7 @@ interface AlgorithmIdentifierProvider
      * @param string $oid Object identifier in dotted format
      * @return bool
      */
-    public function supportsOID($oid);
+    public function supportsOID(string $oid): bool;
     
     /**
      * Get the name of a class that implements algorithm identifier for given
@@ -28,5 +30,5 @@ interface AlgorithmIdentifierProvider
      * @return string Fully qualified name of a class that extends
      *         SpecificAlgorithmIdentifier
      */
-    public function getClassByOID($oid);
+    public function getClassByOID(string $oid): string;
 }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Asymmetric/ECPublicKeyAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Asymmetric/ECPublicKeyAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric;
 
 use ASN1\Type\UnspecifiedType;
@@ -234,7 +236,7 @@ class ECPublicKeyAlgorithmIdentifier extends SpecificAlgorithmIdentifier impleme
     /**
      * Constructor.
      *
-     * @param string OID Curve identifier
+     * @param string $named_curve Curve identifier
      */
     public function __construct($named_curve)
     {
@@ -247,7 +249,7 @@ class ECPublicKeyAlgorithmIdentifier extends SpecificAlgorithmIdentifier impleme
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "ecPublicKey";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Asymmetric/RSAEncryptionAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Asymmetric/RSAEncryptionAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric;
 
 use ASN1\Type\UnspecifiedType;
@@ -38,7 +40,7 @@ class RSAEncryptionAlgorithmIdentifier extends SpecificAlgorithmIdentifier imple
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "rsaEncryption";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Cipher/AES128CBCAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Cipher/AES128CBCAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Cipher;
 
 /**
@@ -27,7 +29,7 @@ class AES128CBCAlgorithmIdentifier extends AESCBCAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "aes128-CBC";
     }
@@ -37,7 +39,7 @@ class AES128CBCAlgorithmIdentifier extends AESCBCAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function keySize()
+    public function keySize(): int
     {
         return 16;
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Cipher/AES192CBCAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Cipher/AES192CBCAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Cipher;
 
 /**
@@ -27,7 +29,7 @@ class AES192CBCAlgorithmIdentifier extends AESCBCAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "aes192-CBC";
     }
@@ -37,7 +39,7 @@ class AES192CBCAlgorithmIdentifier extends AESCBCAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function keySize()
+    public function keySize(): int
     {
         return 24;
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Cipher/AES256CBCAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Cipher/AES256CBCAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Cipher;
 
 /**
@@ -27,7 +29,7 @@ class AES256CBCAlgorithmIdentifier extends AESCBCAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "aes256-CBC";
     }
@@ -37,7 +39,7 @@ class AES256CBCAlgorithmIdentifier extends AESCBCAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function keySize()
+    public function keySize(): int
     {
         return 32;
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Cipher/AESCBCAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Cipher/AESCBCAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Cipher;
 
 use ASN1\Type\UnspecifiedType;
@@ -68,7 +70,7 @@ abstract class AESCBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function blockSize()
+    public function blockSize(): int
     {
         return 16;
     }
@@ -78,7 +80,7 @@ abstract class AESCBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function ivSize()
+    public function ivSize(): int
     {
         return 16;
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Cipher/BlockCipherAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Cipher/BlockCipherAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Cipher;
 
 /**
@@ -12,5 +14,5 @@ abstract class BlockCipherAlgorithmIdentifier extends CipherAlgorithmIdentifier
      *
      * @return int
      */
-    abstract public function blockSize();
+    abstract public function blockSize(): int;
 }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Cipher/CipherAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Cipher/CipherAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Cipher;
 
 use Sop\CryptoTypes\AlgorithmIdentifier\SpecificAlgorithmIdentifier;
@@ -21,14 +23,14 @@ abstract class CipherAlgorithmIdentifier extends SpecificAlgorithmIdentifier
      *
      * @return int
      */
-    abstract public function keySize();
+    abstract public function keySize(): int;
     
     /**
      * Get the initialization vector size in bytes.
      *
      * @return int
      */
-    abstract public function ivSize();
+    abstract public function ivSize(): int;
     
     /**
      * Get initialization vector.

--- a/lib/CryptoTypes/AlgorithmIdentifier/Cipher/DESCBCAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Cipher/DESCBCAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Cipher;
 
 use ASN1\Type\UnspecifiedType;
@@ -39,7 +41,7 @@ class DESCBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "desCBC";
     }
@@ -78,7 +80,7 @@ class DESCBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function blockSize()
+    public function blockSize(): int
     {
         return 8;
     }
@@ -88,7 +90,7 @@ class DESCBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function keySize()
+    public function keySize(): int
     {
         return 8;
     }
@@ -98,7 +100,7 @@ class DESCBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function ivSize()
+    public function ivSize(): int
     {
         return 8;
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Cipher/DESEDE3CBCAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Cipher/DESEDE3CBCAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Cipher;
 
 use ASN1\Type\UnspecifiedType;
@@ -40,7 +42,7 @@ class DESEDE3CBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "des-EDE3-CBC";
     }
@@ -79,7 +81,7 @@ class DESEDE3CBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function blockSize()
+    public function blockSize(): int
     {
         return 8;
     }
@@ -89,7 +91,7 @@ class DESEDE3CBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function keySize()
+    public function keySize(): int
     {
         return 24;
     }
@@ -99,7 +101,7 @@ class DESEDE3CBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function ivSize()
+    public function ivSize(): int
     {
         return 8;
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Cipher/RC2CBCAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Cipher/RC2CBCAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Cipher;
 
 use ASN1\Element;
@@ -102,7 +104,7 @@ class RC2CBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "rc2-cbc";
     }
@@ -145,7 +147,7 @@ class RC2CBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      *
      * @return int
      */
-    public function effectiveKeyBits()
+    public function effectiveKeyBits(): int
     {
         return $this->_effectiveKeyBits;
     }
@@ -175,7 +177,7 @@ class RC2CBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function blockSize()
+    public function blockSize(): int
     {
         return 8;
     }
@@ -185,7 +187,7 @@ class RC2CBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function keySize()
+    public function keySize(): int
     {
         return (int) round($this->_effectiveKeyBits / 8);
     }
@@ -195,7 +197,7 @@ class RC2CBCAlgorithmIdentifier extends BlockCipherAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function ivSize()
+    public function ivSize(): int
     {
         return 8;
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Feature/AlgorithmIdentifierType.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Feature/AlgorithmIdentifierType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Feature;
 
 /**
@@ -19,7 +21,7 @@ interface AlgorithmIdentifierType
      *
      * @return string
      */
-    public function name();
+    public function name(): string;
     
     /**
      * Generate ASN.1 structure.

--- a/lib/CryptoTypes/AlgorithmIdentifier/Feature/AsymmetricCryptoAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Feature/AsymmetricCryptoAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Feature;
 
 /**

--- a/lib/CryptoTypes/AlgorithmIdentifier/Feature/EncryptionAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Feature/EncryptionAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Feature;
 
 /**

--- a/lib/CryptoTypes/AlgorithmIdentifier/Feature/HashAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Feature/HashAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Feature;
 
 /**

--- a/lib/CryptoTypes/AlgorithmIdentifier/Feature/PRFAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Feature/PRFAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Feature;
 
 /**

--- a/lib/CryptoTypes/AlgorithmIdentifier/Feature/SignatureAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Feature/SignatureAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Feature;
 
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
@@ -15,5 +17,5 @@ interface SignatureAlgorithmIdentifier extends AlgorithmIdentifierType
      * @param AlgorithmIdentifier $algo
      * @return bool
      */
-    public function supportsKeyAlgorithm(AlgorithmIdentifier $algo);
+    public function supportsKeyAlgorithm(AlgorithmIdentifier $algo): bool;
 }

--- a/lib/CryptoTypes/AlgorithmIdentifier/GenericAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/GenericAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier;
 
 use ASN1\Type\UnspecifiedType;
@@ -22,7 +24,7 @@ class GenericAlgorithmIdentifier extends AlgorithmIdentifier
      * @param string $oid Algorithm OID
      * @param UnspecifiedType|null $params Parameters
      */
-    public function __construct($oid, UnspecifiedType $params = null)
+    public function __construct(string $oid, UnspecifiedType $params = null)
     {
         $this->_oid = $oid;
         $this->_params = $params;
@@ -33,7 +35,7 @@ class GenericAlgorithmIdentifier extends AlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return $this->_oid;
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/HMACWithSHA1AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/HMACWithSHA1AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 use ASN1\Type\UnspecifiedType;
@@ -40,7 +42,7 @@ class HMACWithSHA1AlgorithmIdentifier extends SpecificAlgorithmIdentifier implem
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "hmacWithSHA1";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/HMACWithSHA224AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/HMACWithSHA224AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 /**
@@ -22,7 +24,7 @@ class HMACWithSHA224AlgorithmIdentifier extends RFC4231HMACAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "hmacWithSHA224";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/HMACWithSHA256AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/HMACWithSHA256AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 /**
@@ -22,7 +24,7 @@ class HMACWithSHA256AlgorithmIdentifier extends RFC4231HMACAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "hmacWithSHA256";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/HMACWithSHA384AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/HMACWithSHA384AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 /**
@@ -22,7 +24,7 @@ class HMACWithSHA384AlgorithmIdentifier extends RFC4231HMACAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "hmacWithSHA384";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/HMACWithSHA512AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/HMACWithSHA512AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 /**
@@ -22,7 +24,7 @@ class HMACWithSHA512AlgorithmIdentifier extends RFC4231HMACAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "hmacWithSHA512";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/MD5AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/MD5AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 use ASN1\Type\UnspecifiedType;
@@ -54,7 +56,7 @@ class MD5AlgorithmIdentifier extends SpecificAlgorithmIdentifier implements
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "md5";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/RFC4231HMACAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/RFC4231HMACAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 use ASN1\Type\UnspecifiedType;

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA1AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA1AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 use ASN1\Type\UnspecifiedType;
@@ -49,7 +51,7 @@ class SHA1AlgorithmIdentifier extends SpecificAlgorithmIdentifier implements
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "sha1";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA224AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA224AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 /**
@@ -26,7 +28,7 @@ class SHA224AlgorithmIdentifier extends SHA2AlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "sha224";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA256AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA256AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 /**
@@ -25,7 +27,7 @@ class SHA256AlgorithmIdentifier extends SHA2AlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "sha256";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA2AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA2AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 use ASN1\Type\UnspecifiedType;

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA384AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA384AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 /**
@@ -25,7 +27,7 @@ class SHA384AlgorithmIdentifier extends SHA2AlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "sha384";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA512AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Hash/SHA512AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Hash;
 
 /**
@@ -25,7 +27,7 @@ class SHA512AlgorithmIdentifier extends SHA2AlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "sha512";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECDSAWithSHA1AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECDSAWithSHA1AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -22,7 +24,7 @@ class ECDSAWithSHA1AlgorithmIdentifier extends ECSignatureAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "ecdsa-with-SHA1";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECDSAWithSHA224AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECDSAWithSHA224AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -22,7 +24,7 @@ class ECDSAWithSHA224AlgorithmIdentifier extends ECSignatureAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "ecdsa-with-SHA224";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECDSAWithSHA256AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECDSAWithSHA256AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -22,7 +24,7 @@ class ECDSAWithSHA256AlgorithmIdentifier extends ECSignatureAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "ecdsa-with-SHA256";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECDSAWithSHA384AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECDSAWithSHA384AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -22,7 +24,7 @@ class ECDSAWithSHA384AlgorithmIdentifier extends ECSignatureAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "ecdsa-with-SHA384";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECDSAWithSHA512AlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECDSAWithSHA512AlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -22,7 +24,7 @@ class ECDSAWithSHA512AlgorithmIdentifier extends ECSignatureAlgorithmIdentifier
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "ecdsa-with-SHA512";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECSignatureAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/ECSignatureAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 use ASN1\Type\UnspecifiedType;
@@ -57,7 +59,7 @@ abstract class ECSignatureAlgorithmIdentifier extends SpecificAlgorithmIdentifie
      * {@inheritdoc}
      *
      */
-    public function supportsKeyAlgorithm(AlgorithmIdentifier $algo)
+    public function supportsKeyAlgorithm(AlgorithmIdentifier $algo): bool
     {
         return $algo->oid() == self::OID_EC_PUBLIC_KEY;
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/MD2WithRSAEncryptionAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/MD2WithRSAEncryptionAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -22,7 +24,7 @@ class MD2WithRSAEncryptionAlgorithmIdentifier extends RFC3279RSASignatureAlgorit
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "md2WithRSAEncryption";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/MD4WithRSAEncryptionAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/MD4WithRSAEncryptionAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -22,7 +24,7 @@ class MD4WithRSAEncryptionAlgorithmIdentifier extends RFC3279RSASignatureAlgorit
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "md4withRSAEncryption";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/MD5WithRSAEncryptionAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/MD5WithRSAEncryptionAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -22,7 +24,7 @@ class MD5WithRSAEncryptionAlgorithmIdentifier extends RFC3279RSASignatureAlgorit
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "md5WithRSAEncryption";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/RFC3279RSASignatureAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/RFC3279RSASignatureAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 use ASN1\Type\UnspecifiedType;

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/RFC4055RSASignatureAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/RFC4055RSASignatureAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 use ASN1\Type\UnspecifiedType;

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/RSASignatureAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/RSASignatureAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
@@ -17,7 +19,7 @@ abstract class RSASignatureAlgorithmIdentifier extends SpecificAlgorithmIdentifi
      * {@inheritdoc}
      *
      */
-    public function supportsKeyAlgorithm(AlgorithmIdentifier $algo)
+    public function supportsKeyAlgorithm(AlgorithmIdentifier $algo): bool
     {
         return $algo->oid() == self::OID_RSA_ENCRYPTION;
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/SHA1WithRSAEncryptionAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/SHA1WithRSAEncryptionAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -22,7 +24,7 @@ class SHA1WithRSAEncryptionAlgorithmIdentifier extends RFC3279RSASignatureAlgori
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "sha1-with-rsa-signature";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/SHA224WithRSAEncryptionAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/SHA224WithRSAEncryptionAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -23,7 +25,7 @@ class SHA224WithRSAEncryptionAlgorithmIdentifier extends RFC4055RSASignatureAlgo
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "sha224WithRSAEncryption";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/SHA256WithRSAEncryptionAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/SHA256WithRSAEncryptionAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -23,7 +25,7 @@ class SHA256WithRSAEncryptionAlgorithmIdentifier extends RFC4055RSASignatureAlgo
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "sha256WithRSAEncryption";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/SHA384WithRSAEncryptionAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/SHA384WithRSAEncryptionAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -23,7 +25,7 @@ class SHA384WithRSAEncryptionAlgorithmIdentifier extends RFC4055RSASignatureAlgo
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "sha384WithRSAEncryption";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/SHA512WithRSAEncryptionAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/SHA512WithRSAEncryptionAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 /**
@@ -23,7 +25,7 @@ class SHA512WithRSAEncryptionAlgorithmIdentifier extends RFC4055RSASignatureAlgo
      * {@inheritdoc}
      *
      */
-    public function name()
+    public function name(): string
     {
         return "sha512WithRSAEncryption";
     }

--- a/lib/CryptoTypes/AlgorithmIdentifier/Signature/SignatureAlgorithmIdentifierFactory.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/Signature/SignatureAlgorithmIdentifierFactory.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier\Signature;
 
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifierFactory;
 use Sop\CryptoTypes\AlgorithmIdentifier\Feature\AsymmetricCryptoAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Feature\HashAlgorithmIdentifier;
+use Sop\CryptoTypes\AlgorithmIdentifier\Feature\SignatureAlgorithmIdentifier;
 
 /**
  * Factory class for constructing signature algorithm identifiers.
@@ -55,11 +58,11 @@ abstract class SignatureAlgorithmIdentifierFactory
      *        algorithm identifier, eg. RSA or EC
      * @param HashAlgorithmIdentifier $hash_algo Hash algorithm identifier
      * @throws \UnexpectedValueException
-     * @return \Sop\CryptoTypes\AlgorithmIdentifier\Feature\SignatureAlgorithmIdentifier
+     * @return SignatureAlgorithmIdentifier
      */
     public static function algoForAsymmetricCrypto(
         AsymmetricCryptoAlgorithmIdentifier $crypto_algo,
-        HashAlgorithmIdentifier $hash_algo)
+        HashAlgorithmIdentifier $hash_algo): SignatureAlgorithmIdentifier
     {
         switch ($crypto_algo->oid()) {
             case AlgorithmIdentifier::OID_RSA_ENCRYPTION:
@@ -84,7 +87,7 @@ abstract class SignatureAlgorithmIdentifierFactory
      * @throws \UnexpectedValueException
      * @return string
      */
-    private static function _oidForRSA(HashAlgorithmIdentifier $hash_algo)
+    private static function _oidForRSA(HashAlgorithmIdentifier $hash_algo): string
     {
         if (!array_key_exists($hash_algo->oid(), self::MAP_RSA_OID)) {
             throw new \UnexpectedValueException(
@@ -100,7 +103,7 @@ abstract class SignatureAlgorithmIdentifierFactory
      * @throws \UnexpectedValueException
      * @return string
      */
-    private static function _oidForEC(HashAlgorithmIdentifier $hash_algo)
+    private static function _oidForEC(HashAlgorithmIdentifier $hash_algo): string
     {
         if (!array_key_exists($hash_algo->oid(), self::MAP_EC_OID)) {
             throw new \UnexpectedValueException(

--- a/lib/CryptoTypes/AlgorithmIdentifier/SpecificAlgorithmIdentifier.php
+++ b/lib/CryptoTypes/AlgorithmIdentifier/SpecificAlgorithmIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\AlgorithmIdentifier;
 
 use ASN1\Type\UnspecifiedType;

--- a/lib/CryptoTypes/Asymmetric/EC/ECConversion.php
+++ b/lib/CryptoTypes/Asymmetric/EC/ECConversion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Asymmetric\EC;
 
 use ASN1\Type\Primitive\BitString;
@@ -22,7 +24,7 @@ class ECConversion
      * @throws \RuntimeException
      * @return OctetString
      */
-    public static function bitStringToOctetString(BitString $bs)
+    public static function bitStringToOctetString(BitString $bs): OctetString
     {
         $str = $bs->string();
         if ($bs->unusedBits()) {
@@ -40,7 +42,7 @@ class ECConversion
      * @param OctetString $os
      * @return BitString
      */
-    public static function octetStringToBitString(OctetString $os)
+    public static function octetStringToBitString(OctetString $os): BitString
     {
         return new BitString($os->string());
     }
@@ -50,12 +52,13 @@ class ECConversion
      *
      * Defined in SEC 1 section 2.3.7.
      *
-     * @param Integer $num
+     * @param \ASN1\Type\Primitive\Integer $num
      * @param int $mlen Optional desired output length
      * @throws \UnexpectedValueException
      * @return OctetString
      */
-    public static function integerToOctetString(Integer $num, $mlen = null)
+    public static function integerToOctetString(
+        \ASN1\Type\Primitive\Integer $num, int $mlen = null): OctetString
     {
         $gmp = gmp_init($num->number(), 10);
         $str = gmp_export($gmp, 1, GMP_MSW_FIRST | GMP_BIG_ENDIAN);
@@ -78,9 +81,9 @@ class ECConversion
      * Defined in SEC 1 section 2.3.8.
      *
      * @param OctetString $os
-     * @return Integer
+     * @return \ASN1\Type\Primitive\Integer
      */
-    public static function octetStringToInteger(OctetString $os)
+    public static function octetStringToInteger(OctetString $os): \ASN1\Type\Primitive\Integer
     {
         $num = gmp_import($os->string(), 1, GMP_MSW_FIRST | GMP_BIG_ENDIAN);
         return new Integer(gmp_strval($num, 10));
@@ -96,7 +99,7 @@ class ECConversion
      * @param int $mlen Optional desired output length
      * @return string
      */
-    public static function numberToOctets($num, $mlen = null)
+    public static function numberToOctets($num, $mlen = null): string
     {
         return self::integerToOctetString(new Integer($num), $mlen)->string();
     }

--- a/lib/CryptoTypes/Asymmetric/EC/ECPrivateKey.php
+++ b/lib/CryptoTypes/Asymmetric/EC/ECPrivateKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Asymmetric\EC;
 
 use ASN1\Type\Constructed\Sequence;
@@ -11,6 +13,7 @@ use ASN1\Type\Tagged\ExplicitlyTaggedType;
 use Sop\CryptoEncoding\PEM;
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\ECPublicKeyAlgorithmIdentifier;
 use Sop\CryptoTypes\Asymmetric\PrivateKey;
+use Sop\CryptoTypes\Asymmetric\PublicKey;
 
 /**
  * Implements elliptic curve private key type as specified by RFC 5915.
@@ -166,7 +169,7 @@ class ECPrivateKey extends PrivateKey
      * {@inheritdoc}
      *
      */
-    public function algorithmIdentifier()
+    public function algorithmIdentifier(): \Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier
     {
         return new ECPublicKeyAlgorithmIdentifier($this->namedCurve());
     }
@@ -187,7 +190,7 @@ class ECPrivateKey extends PrivateKey
      *
      * @return ECPublicKey
      */
-    public function publicKey()
+    public function publicKey(): PublicKey
     {
         if (!$this->hasPublicKey()) {
             throw new \LogicException("publicKey not set.");
@@ -219,7 +222,7 @@ class ECPrivateKey extends PrivateKey
      * {@inheritdoc}
      *
      */
-    public function toDER()
+    public function toDER(): string
     {
         return $this->toASN1()->toDER();
     }
@@ -229,7 +232,7 @@ class ECPrivateKey extends PrivateKey
      * {@inheritdoc}
      *
      */
-    public function toPEM()
+    public function toPEM(): PEM
     {
         return new PEM(PEM::TYPE_EC_PRIVATE_KEY, $this->toDER());
     }

--- a/lib/CryptoTypes/Asymmetric/EC/ECPublicKey.php
+++ b/lib/CryptoTypes/Asymmetric/EC/ECPublicKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Asymmetric\EC;
 
 use ASN1\Type\Primitive\Integer;
@@ -41,7 +43,7 @@ class ECPublicKey extends PublicKey
      * @param string|null $named_curve Named curve OID
      * @throws \InvalidArgumentException If ECPoint is invalid
      */
-    public function __construct($ec_point, $named_curve = null)
+    public function __construct(string $ec_point, $named_curve = null)
     {
         // first octet must be 0x04 for uncompressed form, and 0x02 or 0x03
         // for compressed form.
@@ -69,7 +71,7 @@ class ECPublicKey extends PublicKey
         }
         $mlen = null;
         if (isset($bits)) {
-            $mlen = ceil($bits / 8);
+            $mlen = (int) ceil($bits / 8);
         }
         $x_os = ECConversion::integerToOctetString(new Integer($x), $mlen)->string();
         $y_os = ECConversion::integerToOctetString(new Integer($y), $mlen)->string();
@@ -118,7 +120,7 @@ class ECPublicKey extends PublicKey
      *
      * @return string
      */
-    public function ECPoint()
+    public function ECPoint(): string
     {
         return $this->_ecPoint;
     }
@@ -128,7 +130,7 @@ class ECPublicKey extends PublicKey
      *
      * @return string[] Tuple of X and Y coordinates as base-10 numbers
      */
-    public function curvePoint()
+    public function curvePoint(): array
     {
         return array_map(
             function ($str) {
@@ -141,13 +143,13 @@ class ECPublicKey extends PublicKey
      *
      * @return string[] Tuple of X and Y field elements as a string.
      */
-    public function curvePointOctets()
+    public function curvePointOctets(): array
     {
         if ($this->isCompressed()) {
             throw new \RuntimeException("EC point compression not supported.");
         }
         $str = substr($this->_ecPoint, 1);
-        list($x, $y) = str_split($str, floor(strlen($str) / 2));
+        list($x, $y) = str_split($str, (int) floor(strlen($str) / 2));
         return [$x, $y];
     }
     
@@ -156,7 +158,7 @@ class ECPublicKey extends PublicKey
      *
      * @return bool
      */
-    public function isCompressed()
+    public function isCompressed(): bool
     {
         $c = ord($this->_ecPoint[0]);
         return $c != 4;
@@ -167,7 +169,7 @@ class ECPublicKey extends PublicKey
      *
      * @return bool
      */
-    public function hasNamedCurve()
+    public function hasNamedCurve(): bool
     {
         return isset($this->_namedCurve);
     }
@@ -178,7 +180,7 @@ class ECPublicKey extends PublicKey
      * @throws \LogicException
      * @return string
      */
-    public function namedCurve()
+    public function namedCurve(): string
     {
         if (!$this->hasNamedCurve()) {
             throw new \LogicException("namedCurve not set.");
@@ -191,7 +193,7 @@ class ECPublicKey extends PublicKey
      * {@inheritdoc}
      *
      */
-    public function algorithmIdentifier()
+    public function algorithmIdentifier(): AlgorithmIdentifier
     {
         return new ECPublicKeyAlgorithmIdentifier($this->namedCurve());
     }
@@ -201,7 +203,7 @@ class ECPublicKey extends PublicKey
      *
      * @return OctetString
      */
-    public function toASN1()
+    public function toASN1(): OctetString
     {
         return new OctetString($this->_ecPoint);
     }
@@ -211,7 +213,7 @@ class ECPublicKey extends PublicKey
      * {@inheritdoc}
      *
      */
-    public function toDER()
+    public function toDER(): string
     {
         return $this->toASN1()->toDER();
     }
@@ -222,7 +224,7 @@ class ECPublicKey extends PublicKey
      *
      * @link https://tools.ietf.org/html/rfc5480#section-2.2
      */
-    public function subjectPublicKeyData()
+    public function subjectPublicKeyData(): string
     {
         // ECPoint is directly mapped to subjectPublicKey
         return $this->_ecPoint;

--- a/lib/CryptoTypes/Asymmetric/OneAsymmetricKey.php
+++ b/lib/CryptoTypes/Asymmetric/OneAsymmetricKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Asymmetric;
 
 use ASN1\Type\Constructed\Sequence;
@@ -58,7 +60,7 @@ class OneAsymmetricKey
      * @param AlgorithmIdentifier $algo Algorithm
      * @param string $key Private key data
      */
-    public function __construct(AlgorithmIdentifier $algo, $key)
+    public function __construct(AlgorithmIdentifier $algo, string $key)
     {
         $this->_version = self::VERSION_1;
         $this->_algo = $algo;
@@ -97,7 +99,7 @@ class OneAsymmetricKey
      * @param string $data
      * @return self
      */
-    public static function fromDER($data)
+    public static function fromDER(string $data)
     {
         return self::fromASN1(Sequence::fromDER($data));
     }
@@ -141,7 +143,7 @@ class OneAsymmetricKey
      *
      * @return AlgorithmIdentifier
      */
-    public function algorithmIdentifier()
+    public function algorithmIdentifier(): AlgorithmIdentifier
     {
         return $this->_algo;
     }
@@ -151,7 +153,7 @@ class OneAsymmetricKey
      *
      * @return string
      */
-    public function privateKeyData()
+    public function privateKeyData(): string
     {
         return $this->_privateKeyData;
     }
@@ -162,7 +164,7 @@ class OneAsymmetricKey
      * @throws \RuntimeException
      * @return PrivateKey
      */
-    public function privateKey()
+    public function privateKey(): PrivateKey
     {
         $algo = $this->algorithmIdentifier();
         switch ($algo->oid()) {
@@ -194,7 +196,7 @@ class OneAsymmetricKey
      *
      * @return PublicKeyInfo
      */
-    public function publicKeyInfo()
+    public function publicKeyInfo(): PublicKeyInfo
     {
         return $this->privateKey()
             ->publicKey()
@@ -206,7 +208,7 @@ class OneAsymmetricKey
      *
      * @return Sequence
      */
-    public function toASN1()
+    public function toASN1(): Sequence
     {
         $elements = array(new Integer($this->_version), $this->_algo->toASN1(),
             new OctetString($this->_privateKeyData));
@@ -219,7 +221,7 @@ class OneAsymmetricKey
      *
      * @return string
      */
-    public function toDER()
+    public function toDER(): string
     {
         return $this->toASN1()->toDER();
     }
@@ -229,7 +231,7 @@ class OneAsymmetricKey
      *
      * @return PEM
      */
-    public function toPEM()
+    public function toPEM(): PEM
     {
         return new PEM(PEM::TYPE_PRIVATE_KEY, $this->toDER());
     }

--- a/lib/CryptoTypes/Asymmetric/PrivateKey.php
+++ b/lib/CryptoTypes/Asymmetric/PrivateKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Asymmetric;
 
 use Sop\CryptoEncoding\PEM;
@@ -14,35 +16,35 @@ abstract class PrivateKey
      *
      * @return \Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier
      */
-    abstract public function algorithmIdentifier();
+    abstract public function algorithmIdentifier(): \Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
     
     /**
      * Get public key component of the asymmetric key pair.
      *
      * @return PublicKey
      */
-    abstract public function publicKey();
+    abstract public function publicKey(): PublicKey;
     
     /**
      * Get DER encoding of the private key.
      *
      * @return string
      */
-    abstract public function toDER();
+    abstract public function toDER(): string;
     
     /**
      * Get the private key as a PEM.
      *
      * @return PEM
      */
-    abstract public function toPEM();
+    abstract public function toPEM(): PEM;
     
     /**
      * Get the private key as a PrivateKeyInfo type.
      *
      * @return PrivateKeyInfo
      */
-    public function privateKeyInfo()
+    public function privateKeyInfo(): PrivateKeyInfo
     {
         return PrivateKeyInfo::fromPrivateKey($this);
     }

--- a/lib/CryptoTypes/Asymmetric/PrivateKeyInfo.php
+++ b/lib/CryptoTypes/Asymmetric/PrivateKeyInfo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Asymmetric;
 
 /**

--- a/lib/CryptoTypes/Asymmetric/PublicKey.php
+++ b/lib/CryptoTypes/Asymmetric/PublicKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Asymmetric;
 
 use Sop\CryptoEncoding\PEM;
@@ -21,14 +23,14 @@ abstract class PublicKey
      *
      * @return string
      */
-    abstract public function toDER();
+    abstract public function toDER(): string;
     
     /**
      * Get the public key data for subjectPublicKey in PublicKeyInfo.
      *
      * @return string
      */
-    public function subjectPublicKeyData()
+    public function subjectPublicKeyData(): string
     {
         return $this->toDER();
     }
@@ -38,7 +40,7 @@ abstract class PublicKey
      *
      * @return PublicKeyInfo
      */
-    public function publicKeyInfo()
+    public function publicKeyInfo(): PublicKeyInfo
     {
         return PublicKeyInfo::fromPublicKey($this);
     }

--- a/lib/CryptoTypes/Asymmetric/PublicKeyInfo.php
+++ b/lib/CryptoTypes/Asymmetric/PublicKeyInfo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Asymmetric;
 
 use ASN1\Type\Constructed\Sequence;
@@ -35,7 +37,7 @@ class PublicKeyInfo
      * @param AlgorithmIdentifier $algo Algorithm
      * @param string $key Public key data
      */
-    public function __construct(AlgorithmIdentifier $algo, $key)
+    public function __construct(AlgorithmIdentifier $algo, string $key)
     {
         $this->_algo = $algo;
         $this->_publicKeyData = $key;
@@ -92,7 +94,7 @@ class PublicKeyInfo
      * @param string $data
      * @return self
      */
-    public static function fromDER($data)
+    public static function fromDER(string $data)
     {
         return self::fromASN1(Sequence::fromDER($data));
     }
@@ -102,7 +104,7 @@ class PublicKeyInfo
      *
      * @return AlgorithmIdentifier
      */
-    public function algorithmIdentifier()
+    public function algorithmIdentifier(): AlgorithmIdentifier
     {
         return $this->_algo;
     }
@@ -112,7 +114,7 @@ class PublicKeyInfo
      *
      * @return string
      */
-    public function publicKeyData()
+    public function publicKeyData(): string
     {
         return $this->_publicKeyData;
     }
@@ -123,7 +125,7 @@ class PublicKeyInfo
      * @throws \RuntimeException
      * @return PublicKey
      */
-    public function publicKey()
+    public function publicKey(): PublicKey
     {
         $algo = $this->algorithmIdentifier();
         switch ($algo->oid()) {
@@ -149,7 +151,7 @@ class PublicKeyInfo
      * @link https://tools.ietf.org/html/rfc5280#section-4.2.1.2
      * @return string 20 bytes (160 bits) long identifier
      */
-    public function keyIdentifier()
+    public function keyIdentifier(): string
     {
         return sha1($this->_publicKeyData, true);
     }
@@ -160,7 +162,7 @@ class PublicKeyInfo
      * @link https://tools.ietf.org/html/rfc5280#section-4.2.1.2
      * @return string 8 bytes (64 bits) long identifier
      */
-    public function keyIdentifier64()
+    public function keyIdentifier64(): string
     {
         $id = substr($this->keyIdentifier(), -8);
         $c = (ord($id[0]) & 0x0f) | 0x40;
@@ -173,7 +175,7 @@ class PublicKeyInfo
      *
      * @return Sequence
      */
-    public function toASN1()
+    public function toASN1(): Sequence
     {
         return new Sequence($this->_algo->toASN1(),
             new BitString($this->_publicKeyData));
@@ -184,7 +186,7 @@ class PublicKeyInfo
      *
      * @return string
      */
-    public function toDER()
+    public function toDER(): string
     {
         return $this->toASN1()->toDER();
     }
@@ -194,7 +196,7 @@ class PublicKeyInfo
      *
      * @return PEM
      */
-    public function toPEM()
+    public function toPEM(): PEM
     {
         return new PEM(PEM::TYPE_PUBLIC_KEY, $this->toDER());
     }

--- a/lib/CryptoTypes/Asymmetric/RSA/RSAPrivateKey.php
+++ b/lib/CryptoTypes/Asymmetric/RSA/RSAPrivateKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Asymmetric\RSA;
 
 use ASN1\Type\Constructed\Sequence;
@@ -7,6 +9,7 @@ use ASN1\Type\Primitive\Integer;
 use Sop\CryptoEncoding\PEM;
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\RSAEncryptionAlgorithmIdentifier;
 use Sop\CryptoTypes\Asymmetric\PrivateKey;
+use Sop\CryptoTypes\Asymmetric\PublicKey;
 
 /**
  * Implements PKCS #1 RSAPrivateKey ASN.1 type.
@@ -133,7 +136,7 @@ class RSAPrivateKey extends PrivateKey
      * @param string $data
      * @return self
      */
-    public static function fromDER($data)
+    public static function fromDER(string $data)
     {
         return self::fromASN1(Sequence::fromDER($data));
     }
@@ -239,7 +242,7 @@ class RSAPrivateKey extends PrivateKey
      * {@inheritdoc}
      *
      */
-    public function algorithmIdentifier()
+    public function algorithmIdentifier(): \Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier
     {
         return new RSAEncryptionAlgorithmIdentifier();
     }
@@ -250,7 +253,7 @@ class RSAPrivateKey extends PrivateKey
      *
      * @return RSAPublicKey
      */
-    public function publicKey()
+    public function publicKey(): PublicKey
     {
         return new RSAPublicKey($this->_modulus, $this->_publicExponent);
     }
@@ -260,7 +263,7 @@ class RSAPrivateKey extends PrivateKey
      *
      * @return Sequence
      */
-    public function toASN1()
+    public function toASN1(): Sequence
     {
         return new Sequence(new Integer(0), new Integer($this->_modulus),
             new Integer($this->_publicExponent),
@@ -274,7 +277,7 @@ class RSAPrivateKey extends PrivateKey
      * {@inheritdoc}
      *
      */
-    public function toDER()
+    public function toDER(): string
     {
         return $this->toASN1()->toDER();
     }
@@ -284,7 +287,7 @@ class RSAPrivateKey extends PrivateKey
      * {@inheritdoc}
      *
      */
-    public function toPEM()
+    public function toPEM(): PEM
     {
         return new PEM(PEM::TYPE_RSA_PRIVATE_KEY, $this->toDER());
     }

--- a/lib/CryptoTypes/Asymmetric/RSA/RSAPublicKey.php
+++ b/lib/CryptoTypes/Asymmetric/RSA/RSAPublicKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Asymmetric\RSA;
 
 use ASN1\Type\Constructed\Sequence;
@@ -66,7 +68,7 @@ class RSAPublicKey extends PublicKey
      * @param string $data
      * @return self
      */
-    public static function fromDER($data)
+    public static function fromDER(string $data)
     {
         return self::fromASN1(Sequence::fromDER($data));
     }
@@ -119,7 +121,7 @@ class RSAPublicKey extends PublicKey
      * {@inheritdoc}
      *
      */
-    public function algorithmIdentifier()
+    public function algorithmIdentifier(): AlgorithmIdentifier
     {
         return new RSAEncryptionAlgorithmIdentifier();
     }
@@ -129,7 +131,7 @@ class RSAPublicKey extends PublicKey
      *
      * @return Sequence
      */
-    public function toASN1()
+    public function toASN1(): Sequence
     {
         return new Sequence(new Integer($this->_modulus),
             new Integer($this->_publicExponent));
@@ -140,7 +142,7 @@ class RSAPublicKey extends PublicKey
      * {@inheritdoc}
      *
      */
-    public function toDER()
+    public function toDER(): string
     {
         return $this->toASN1()->toDER();
     }
@@ -150,7 +152,7 @@ class RSAPublicKey extends PublicKey
      *
      * @return PEM
      */
-    public function toPEM()
+    public function toPEM(): PEM
     {
         return new PEM(PEM::TYPE_RSA_PUBLIC_KEY, $this->toDER());
     }

--- a/lib/CryptoTypes/Signature/ECSignature.php
+++ b/lib/CryptoTypes/Signature/ECSignature.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Signature;
 
 use ASN1\Type\Constructed\Sequence;
@@ -64,7 +66,7 @@ class ECSignature extends Signature
      * @param string $data
      * @return self
      */
-    public static function fromDER($data)
+    public static function fromDER(string $data)
     {
         return self::fromASN1(Sequence::fromDER($data));
     }
@@ -94,7 +96,7 @@ class ECSignature extends Signature
      *
      * @return Sequence
      */
-    public function toASN1()
+    public function toASN1(): Sequence
     {
         return new Sequence(new Integer($this->_r), new Integer($this->_s));
     }
@@ -104,7 +106,7 @@ class ECSignature extends Signature
      *
      * @return string
      */
-    public function toDER()
+    public function toDER(): string
     {
         return $this->toASN1()->toDER();
     }
@@ -114,7 +116,7 @@ class ECSignature extends Signature
      * {@inheritdoc}
      *
      */
-    public function bitString()
+    public function bitString(): BitString
     {
         return new BitString($this->toDER());
     }

--- a/lib/CryptoTypes/Signature/GenericSignature.php
+++ b/lib/CryptoTypes/Signature/GenericSignature.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Signature;
 
 use ASN1\Type\Primitive\BitString;
@@ -42,7 +44,7 @@ class GenericSignature extends Signature
      *
      * @return AlgorithmIdentifierType
      */
-    public function signatureAlgorithm()
+    public function signatureAlgorithm(): AlgorithmIdentifierType
     {
         return $this->_signatureAlgorithm;
     }
@@ -52,7 +54,7 @@ class GenericSignature extends Signature
      * {@inheritdoc}
      *
      */
-    public function bitString()
+    public function bitString(): BitString
     {
         return $this->_signature;
     }

--- a/lib/CryptoTypes/Signature/RSASignature.php
+++ b/lib/CryptoTypes/Signature/RSASignature.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Signature;
 
 use ASN1\Type\Primitive\BitString;
@@ -36,7 +38,7 @@ class RSASignature extends Signature
      * @param string $signature Signature bits
      * @return self
      */
-    public static function fromSignatureString($signature)
+    public static function fromSignatureString(string $signature)
     {
         $obj = new self();
         $obj->_signature = strval($signature);
@@ -48,7 +50,7 @@ class RSASignature extends Signature
      * {@inheritdoc}
      *
      */
-    public function bitString()
+    public function bitString(): BitString
     {
         return new BitString($this->_signature);
     }

--- a/lib/CryptoTypes/Signature/Signature.php
+++ b/lib/CryptoTypes/Signature/Signature.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sop\CryptoTypes\Signature;
 
 use ASN1\Type\Primitive\BitString;
@@ -26,7 +28,7 @@ abstract class Signature
      * @param AlgorithmIdentifierType $algo Algorithm identifier
      * @return self
      */
-    public static function fromSignatureData($data, AlgorithmIdentifierType $algo)
+    public static function fromSignatureData(string $data, AlgorithmIdentifierType $algo)
     {
         if ($algo instanceof RSASignatureAlgorithmIdentifier) {
             return RSASignature::fromSignatureString($data);

--- a/test/unit/PrivateKeyInfoTest.php
+++ b/test/unit/PrivateKeyInfoTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\Integer;
 use ASN1\Type\Primitive\ObjectIdentifier;
@@ -240,7 +242,7 @@ class PrivateKeyInfoTest_InvalidECAlgo extends SpecificAlgorithmIdentifier
     {
         $this->_oid = self::OID_EC_PUBLIC_KEY;
     }
-    public function name()
+    public function name(): string
     {
         return "";
     }

--- a/test/unit/PrivateKeyTest.php
+++ b/test/unit/PrivateKeyTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use Sop\CryptoEncoding\PEM;
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\ECPublicKeyAlgorithmIdentifier;
 use Sop\CryptoTypes\Asymmetric\EC\ECPrivateKey;

--- a/test/unit/PublicKeyInfoTest.php
+++ b/test/unit/PublicKeyInfoTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Primitive\ObjectIdentifier;
 use Sop\CryptoEncoding\PEM;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
@@ -189,7 +191,7 @@ class PubliceKeyInfoTest_InvalidECAlgo extends SpecificAlgorithmIdentifier
     {
         $this->_oid = self::OID_EC_PUBLIC_KEY;
     }
-    public function name()
+    public function name(): string
     {
         return "";
     }

--- a/test/unit/PublicKeyTest.php
+++ b/test/unit/PublicKeyTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use Sop\CryptoEncoding\PEM;
 use Sop\CryptoTypes\Asymmetric\EC\ECPublicKey;
 use Sop\CryptoTypes\Asymmetric\PublicKey;

--- a/test/unit/algo-id/AIFactoryTest.php
+++ b/test/unit/algo-id/AIFactoryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\ObjectIdentifier;
 use ASN1\Type\UnspecifiedType;
@@ -35,11 +37,11 @@ class AIFactoryTest extends PHPUnit_Framework_TestCase
 
 class AIFactoryTest_Provider implements AlgorithmIdentifierProvider
 {
-    public function supportsOID($oid)
+    public function supportsOID(string $oid): bool
     {
         return "1.3.6.1.3" == $oid;
     }
-    public function getClassByOID($oid)
+    public function getClassByOID(string $oid): string
     {
         return AIFactoryTest_CustomAlgo::class;
     }
@@ -51,7 +53,7 @@ class AIFactoryTest_CustomAlgo extends SpecificAlgorithmIdentifier
     {
         return new self();
     }
-    public function name()
+    public function name(): string
     {
         return "";
     }

--- a/test/unit/algo-id/AlgorithmIdentifierTest.php
+++ b/test/unit/algo-id/AlgorithmIdentifierTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\NullType;
 use ASN1\Type\Primitive\ObjectIdentifier;

--- a/test/unit/algo-id/GenericAlgorithmIdentifierTest.php
+++ b/test/unit/algo-id/GenericAlgorithmIdentifierTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\Integer;
 use ASN1\Type\UnspecifiedType;

--- a/test/unit/algo-id/asymmetric/ECPKAITest.php
+++ b/test/unit/algo-id/asymmetric/ECPKAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\ECPublicKeyAlgorithmIdentifier;

--- a/test/unit/algo-id/asymmetric/RSAEncAITest.php
+++ b/test/unit/algo-id/asymmetric/RSAEncAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\RSAEncryptionAlgorithmIdentifier;

--- a/test/unit/algo-id/cipher/AES128CBCAITest.php
+++ b/test/unit/algo-id/cipher/AES128CBCAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Cipher\AES128CBCAlgorithmIdentifier;

--- a/test/unit/algo-id/cipher/AES192CBCAITest.php
+++ b/test/unit/algo-id/cipher/AES192CBCAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Cipher\AES192CBCAlgorithmIdentifier;

--- a/test/unit/algo-id/cipher/AES256CBCAITest.php
+++ b/test/unit/algo-id/cipher/AES256CBCAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Cipher\AES256CBCAlgorithmIdentifier;

--- a/test/unit/algo-id/cipher/DESCBCAITest.php
+++ b/test/unit/algo-id/cipher/DESCBCAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Cipher\DESCBCAlgorithmIdentifier;

--- a/test/unit/algo-id/cipher/DESEDE3CBCAITest.php
+++ b/test/unit/algo-id/cipher/DESEDE3CBCAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Cipher\DESEDE3CBCAlgorithmIdentifier;

--- a/test/unit/algo-id/cipher/RC2CBCAITest.php
+++ b/test/unit/algo-id/cipher/RC2CBCAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\ObjectIdentifier;
 use ASN1\Type\Primitive\OctetString;

--- a/test/unit/algo-id/hash/HMACWithSHA1AITest.php
+++ b/test/unit/algo-id/hash/HMACWithSHA1AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\NullType;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;

--- a/test/unit/algo-id/hash/HMACWithSHA224AITest.php
+++ b/test/unit/algo-id/hash/HMACWithSHA224AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Hash\HMACWithSHA224AlgorithmIdentifier;

--- a/test/unit/algo-id/hash/HMACWithSHA256AITest.php
+++ b/test/unit/algo-id/hash/HMACWithSHA256AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Hash\HMACWithSHA256AlgorithmIdentifier;

--- a/test/unit/algo-id/hash/HMACWithSHA384AITest.php
+++ b/test/unit/algo-id/hash/HMACWithSHA384AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Hash\HMACWithSHA384AlgorithmIdentifier;

--- a/test/unit/algo-id/hash/HMACWithSHA512AITest.php
+++ b/test/unit/algo-id/hash/HMACWithSHA512AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Hash\HMACWithSHA512AlgorithmIdentifier;

--- a/test/unit/algo-id/hash/MD5AITest.php
+++ b/test/unit/algo-id/hash/MD5AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Hash\MD5AlgorithmIdentifier;

--- a/test/unit/algo-id/hash/RFC4231HMACAITest.php
+++ b/test/unit/algo-id/hash/RFC4231HMACAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\Boolean;
 use ASN1\Type\Primitive\NullType;

--- a/test/unit/algo-id/hash/SHA1AITest.php
+++ b/test/unit/algo-id/hash/SHA1AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\NullType;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;

--- a/test/unit/algo-id/hash/SHA224AITest.php
+++ b/test/unit/algo-id/hash/SHA224AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\NullType;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;

--- a/test/unit/algo-id/hash/SHA256AITest.php
+++ b/test/unit/algo-id/hash/SHA256AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Hash\SHA256AlgorithmIdentifier;

--- a/test/unit/algo-id/hash/SHA384AITest.php
+++ b/test/unit/algo-id/hash/SHA384AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Hash\SHA384AlgorithmIdentifier;

--- a/test/unit/algo-id/hash/SHA512AITest.php
+++ b/test/unit/algo-id/hash/SHA512AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Hash\SHA512AlgorithmIdentifier;

--- a/test/unit/algo-id/signature/ECDSAAITest.php
+++ b/test/unit/algo-id/signature/ECDSAAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\ECPublicKeyAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\RSAEncryptionAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\ECDSAWithSHA1AlgorithmIdentifier;

--- a/test/unit/algo-id/signature/ECDSAWithSHA1AITest.php
+++ b/test/unit/algo-id/signature/ECDSAWithSHA1AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\NullType;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;

--- a/test/unit/algo-id/signature/ECDSAWithSHA224AITest.php
+++ b/test/unit/algo-id/signature/ECDSAWithSHA224AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\ECDSAWithSHA224AlgorithmIdentifier;

--- a/test/unit/algo-id/signature/ECDSAWithSHA256AITest.php
+++ b/test/unit/algo-id/signature/ECDSAWithSHA256AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\ECDSAWithSHA256AlgorithmIdentifier;

--- a/test/unit/algo-id/signature/ECDSAWithSHA384AITest.php
+++ b/test/unit/algo-id/signature/ECDSAWithSHA384AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\ECDSAWithSHA384AlgorithmIdentifier;

--- a/test/unit/algo-id/signature/ECDSAWithSHA512AITest.php
+++ b/test/unit/algo-id/signature/ECDSAWithSHA512AITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\ECDSAWithSHA512AlgorithmIdentifier;

--- a/test/unit/algo-id/signature/MD2WithRSAAITest.php
+++ b/test/unit/algo-id/signature/MD2WithRSAAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\MD2WithRSAEncryptionAlgorithmIdentifier;

--- a/test/unit/algo-id/signature/MD4WithRSAAITest.php
+++ b/test/unit/algo-id/signature/MD4WithRSAAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\MD4WithRSAEncryptionAlgorithmIdentifier;

--- a/test/unit/algo-id/signature/MD5WithRSAAITest.php
+++ b/test/unit/algo-id/signature/MD5WithRSAAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\MD5WithRSAEncryptionAlgorithmIdentifier;

--- a/test/unit/algo-id/signature/RSASigAITest.php
+++ b/test/unit/algo-id/signature/RSASigAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\ECPublicKeyAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\RSAEncryptionAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\SHA1WithRSAEncryptionAlgorithmIdentifier;

--- a/test/unit/algo-id/signature/SHA1WithRSAAITest.php
+++ b/test/unit/algo-id/signature/SHA1WithRSAAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\SHA1WithRSAEncryptionAlgorithmIdentifier;

--- a/test/unit/algo-id/signature/SHA224WithRSAAITest.php
+++ b/test/unit/algo-id/signature/SHA224WithRSAAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\SHA224WithRSAEncryptionAlgorithmIdentifier;

--- a/test/unit/algo-id/signature/SHA256WithRSAAITest.php
+++ b/test/unit/algo-id/signature/SHA256WithRSAAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\SHA256WithRSAEncryptionAlgorithmIdentifier;

--- a/test/unit/algo-id/signature/SHA384WithRSAAITest.php
+++ b/test/unit/algo-id/signature/SHA384WithRSAAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\SHA384WithRSAEncryptionAlgorithmIdentifier;

--- a/test/unit/algo-id/signature/SHA512WithRSAAITest.php
+++ b/test/unit/algo-id/signature/SHA512WithRSAAITest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\SHA512WithRSAEncryptionAlgorithmIdentifier;

--- a/test/unit/algo-id/signature/SignatureFactoryTest.php
+++ b/test/unit/algo-id/signature/SignatureFactoryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\ECPublicKeyAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\RSAEncryptionAlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Feature\AsymmetricCryptoAlgorithmIdentifier;
@@ -114,7 +116,7 @@ class SignatureFactoryTest extends PHPUnit_Framework_TestCase
 class SignatureFactoryTest_InvalidCryptoAlgo extends SpecificAlgorithmIdentifier implements 
     AsymmetricCryptoAlgorithmIdentifier
 {
-    public function name()
+    public function name(): string
     {
         return "test";
     }
@@ -127,7 +129,7 @@ class SignatureFactoryTest_InvalidCryptoAlgo extends SpecificAlgorithmIdentifier
 class SignatureFactoryTest_InvalidHashAlgo extends SpecificAlgorithmIdentifier implements 
     HashAlgorithmIdentifier
 {
-    public function name()
+    public function name(): string
     {
         return "test";
     }

--- a/test/unit/ec/BS2OSTest.php
+++ b/test/unit/ec/BS2OSTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Primitive\BitString;
 use ASN1\Type\Primitive\OctetString;
 use Sop\CryptoTypes\Asymmetric\EC\ECConversion;

--- a/test/unit/ec/ECPrivateKeyTest.php
+++ b/test/unit/ec/ECPrivateKeyTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\Integer;
 use Sop\CryptoEncoding\PEM;

--- a/test/unit/ec/ECPublicKeyTest.php
+++ b/test/unit/ec/ECPublicKeyTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use Sop\CryptoEncoding\PEM;
 use Sop\CryptoTypes\AlgorithmIdentifier\Asymmetric\ECPublicKeyAlgorithmIdentifier;
 use Sop\CryptoTypes\Asymmetric\EC\ECPublicKey;

--- a/test/unit/ec/I2OSTest.php
+++ b/test/unit/ec/I2OSTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Primitive\Integer;
 use ASN1\Type\Primitive\OctetString;
 use Sop\CryptoTypes\Asymmetric\EC\ECConversion;

--- a/test/unit/rsa/RSAPrivateKeyTest.php
+++ b/test/unit/rsa/RSAPrivateKeyTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\Integer;
 use Sop\CryptoEncoding\PEM;

--- a/test/unit/rsa/RSAPublicKeyTest.php
+++ b/test/unit/rsa/RSAPublicKeyTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use Sop\CryptoEncoding\PEM;
 use Sop\CryptoTypes\Asymmetric\RSA\RSAPublicKey;
 

--- a/test/unit/signature/ECSignatureTest.php
+++ b/test/unit/signature/ECSignatureTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\BitString;
 use Sop\CryptoTypes\Signature\ECSignature;

--- a/test/unit/signature/GenericSignatureTest.php
+++ b/test/unit/signature/GenericSignatureTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Primitive\BitString;
 use Sop\CryptoTypes\AlgorithmIdentifier\AlgorithmIdentifier;
 use Sop\CryptoTypes\AlgorithmIdentifier\Signature\SHA1WithRSAEncryptionAlgorithmIdentifier;

--- a/test/unit/signature/RSASignatureTest.php
+++ b/test/unit/signature/RSASignatureTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Primitive\BitString;
 use Sop\CryptoTypes\Signature\RSASignature;
 

--- a/test/unit/signature/SignatureTest.php
+++ b/test/unit/signature/SignatureTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use ASN1\Type\Constructed\Sequence;
 use ASN1\Type\Primitive\Integer;
 use Sop\CryptoTypes\AlgorithmIdentifier\GenericAlgorithmIdentifier;


### PR DESCRIPTION
Still a WIP for now, will review for anything I've missed, and I'll write up final questions I have about what you prefer on certain points. 

I noticed we big integers are passed as an int|string, and we also use the operator overloading in some places.. what about using the GMP type? It would allow us to specify a concrete type, as atm there are some places where we pass these values as length into substr(), which requires an integer.. So on that note, I'd suggest having a safe way to ensure that the big integer is in a valid range for those cases.

For an example, see here: https://github.com/afk11/asn1/blob/c8f422706de5369a5736956e1a6fab7d63edef59/lib/ASN1/Type/Primitive/Integer.php#L127 I need to obtain an integer, so the cast is required.. 

I haven't worked out an approach to take with some of the static classes hinting self, since (as it seemed at the time) this didn't play well when the class was extended. Also ignored the `with*` methods for mutating an object, but those are probably safe.

These notes roughly apply to all the PR's. I'll take another look soon to complete them, and please also let me know if you have suggestions for improvement. (If you have a one liner for code-style fixing/validation, please also let me know!)

https://github.com/sop/crypto-encoding/pull/1#event-1324661193
https://github.com/sop/crypto-bridge/pull/1
https://github.com/sop/asn1/pull/4
https://github.com/sop/x509/pull/1